### PR TITLE
Add tests for operators

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 pub mod operator;
 pub mod memory_line;
 use state::operator::Operator;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -33,12 +33,11 @@ impl State {
     pub fn next_tick(&self) -> State {
         let operator = self.fetch_operator();
 
-        let operator_argument: u8;
-        if operator.requires_arg {
-            operator_argument = self.memory[self.pc + 1];
+        let operator_argument: u8 = if operator.requires_arg {
+            self.memory[self.pc + 1]
         } else {
-            operator_argument = 0;
-        }
+            0
+        };
 
         let mut new_state = self.execute_operator(operator, operator_argument);
 

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -88,3 +88,24 @@ fn add() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn or() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.memory[50] = 20;
+
+    state.ac = 10;
+
+    let new_state = (operator::OR.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac | 20);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -362,3 +362,20 @@ fn ldi() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn hlt() {
+    let state = State::new([0; 255], [0; 255]);
+
+    let new_state = (operator::HLT.run)(&state, 0);
+
+    assert_eq!(new_state.pc, state.pc + 1);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, true);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -109,3 +109,24 @@ fn or() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn and() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.memory[50] = 20;
+
+    state.ac = 10;
+
+    let new_state = (operator::AND.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac & 20);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -345,3 +345,20 @@ fn out() {
         }
     }
 }
+
+#[test]
+fn ldi() {
+    let state = State::new([0; 255], [0; 255]);
+
+    let new_state = (operator::LDI.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, 50);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -149,3 +149,24 @@ fn not() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn sub() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.memory[50] = 5;
+
+    state.ac = 10;
+
+    let new_state = (operator::SUB.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac - 5);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -130,3 +130,22 @@ fn and() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn not() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 10;
+
+    let new_state = (operator::NOT.run)(&state, 0);
+
+    assert_eq!(new_state.pc, state.pc + 1);
+
+    assert_eq!(new_state.ac, !state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -263,3 +263,41 @@ fn jz_when_accumulator_is_not_zero() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn jnz_when_accumulator_is_not_zero() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 0;
+
+    let new_state = (operator::JNZ.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}
+
+#[test]
+fn jnz_when_accumulator_is_zero() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 2;
+
+    let new_state = (operator::JNZ.run)(&state, 50);
+
+    assert_eq!(new_state.pc, 50);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -225,3 +225,41 @@ fn jn_when_accumulator_is_positive() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn jz_when_accumulator_is_zero() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 0;
+
+    let new_state = (operator::JZ.run)(&state, 50);
+
+    assert_eq!(new_state.pc, 50);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}
+
+#[test]
+fn jz_when_accumulator_is_not_zero() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 2;
+
+    let new_state = (operator::JZ.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -187,3 +187,41 @@ fn jmp() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn jn_when_accumulator_is_negative() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 0b1000000;
+
+    let new_state = (operator::JN.run)(&state, 50);
+
+    assert_eq!(new_state.pc, 50);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}
+
+#[test]
+fn jn_when_accumulator_is_positive() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 0;
+
+    let new_state = (operator::JN.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -301,3 +301,20 @@ fn jnz_when_accumulator_is_zero() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn in_operator() {
+    let state = State::new([0; 255], [1; 255]);
+
+    let new_state = (operator::IN.run)(&state, 0);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, 1);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -1,0 +1,25 @@
+use super::super::state::State;
+use super::operator;
+
+fn compare_u8_slices(slice1: &[u8], slice2: &[u8]) {
+    for (i, item) in slice1.iter().enumerate() {
+        assert_eq!(item, &slice2[i]);
+    }
+}
+
+#[test]
+fn nop() {
+    let state = State::new([0; 255], [0; 255]);
+
+    let new_state = (operator::NOP.run)(&state, 0);
+
+    assert_eq!(new_state.pc, state.pc + 1);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -67,3 +67,24 @@ fn lda() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn add() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.memory[50] = 20;
+
+    state.ac = 10;
+
+    let new_state = (operator::ADD.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac + 20);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -170,3 +170,20 @@ fn sub() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn jmp() {
+    let state = State::new([0; 255], [0; 255]);
+
+    let new_state = (operator::JMP.run)(&state, 50);
+
+    assert_eq!(new_state.pc, 50);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -318,3 +318,30 @@ fn in_operator() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn out() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.output = [22; 40];
+
+    state.ac = 10;
+
+    let new_state = (operator::OUT.run)(&state, 0);
+
+    assert_eq!(new_state.pc, state.pc + 1);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    for (i, item) in new_state.output.iter().enumerate() {
+        if i == 0 {
+            assert_eq!(item, &state.ac);
+        } else {
+            assert_eq!(item, &state.output[i]);
+        }
+    }
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -48,3 +48,22 @@ fn sta() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn lda() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.memory[50] = 25;
+
+    let new_state = (operator::LDA.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.memory[50]);
+
+    assert_eq!(new_state.halt, false);
+
+    compare_u8_slices(&new_state.memory, &state.memory);
+
+    compare_u8_slices(&new_state.output, &state.output);
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -23,3 +23,28 @@ fn nop() {
 
     compare_u8_slices(&new_state.output, &state.output);
 }
+
+#[test]
+fn sta() {
+    let mut state = State::new([0; 255], [0; 255]);
+
+    state.ac = 25;
+
+    let new_state = (operator::STA.run)(&state, 50);
+
+    assert_eq!(new_state.pc, state.pc + 2);
+
+    assert_eq!(new_state.ac, state.ac);
+
+    assert_eq!(new_state.halt, false);
+
+    for (i, item) in new_state.memory.iter().enumerate() {
+        if i == 50 {
+            assert_eq!(item, &state.ac);
+        } else {
+            assert_eq!(item, &state.memory[i]);
+        }
+    }
+
+    compare_u8_slices(&new_state.output, &state.output);
+}


### PR DESCRIPTION
This Pull Request adds tests for the `state/operators` instances.

To verify that the tests pass just run `cargo test` on your terminal :slightly_smiling_face: .